### PR TITLE
Add scikit-learn update to alpine dependency image

### DIFF
--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mundialis/actinia:alpine-dependencies-v1 as base
+FROM mundialis/actinia:alpine-dependencies-2022-07-15 as base
 FROM mundialis/grass-py3-pdal:releasebranch_8_2-alpine as grass
 FROM mundialis/esa-snap:s1tbx-d3eb736 as snap
 

--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -119,3 +119,8 @@ RUN python3 -m ensurepip && pip3 install --upgrade pip pep517 wheel
 RUN curl https://raw.githubusercontent.com/mundialis/actinia_core/main/requirements.txt \
     > requirements.txt && pip3 install -r requirements.txt && \
     rm requirements.txt
+
+# Fix for scikit-learn segmentation fault error
+# TODO: check if this can be removed in future
+RUN apk add openblas openblas-dev lapack lapack-dev
+RUN pip3 install --upgrade scikit-learn


### PR DESCRIPTION
As older scikit learn lead to an errror, a newer version is used here. To avoid long build times, this is already done in the dependency image.
Although we have a scheduled pipeline since yesterday :) I manually build the dependency image (next scheduled build is in one month) and it is currently pushed to dockerhub - will still take a while, then this MR can be merged and the actinia image can be build.